### PR TITLE
Relay errors from Rust to Python

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,4 +1,5 @@
 from slonik import Connection
+from slonik import SlonikException
 
 
 if __name__ == '__main__':
@@ -54,12 +55,12 @@ if __name__ == '__main__':
 
     try:
         conn.get_value('SELECT bar FROM foo')
-    except Exception as e:
+    except SlonikException as e:
         print(e)
 
     try:
         conn.execute('INSERT INTO foo(bar) VALUES (0)')
-    except Exception as e:
+    except SlonikException as e:
         print(e)
 
     #####

--- a/example.py
+++ b/example.py
@@ -50,4 +50,18 @@ if __name__ == '__main__':
     print(list(conn.query('SELECT * FROM toto')))
     conn.execute('ROLLBACK')
 
+    #####
+
+    try:
+        conn.get_value('SELECT bar FROM foo')
+    except Exception as e:
+        print(e)
+
+    try:
+        conn.execute('INSERT INTO foo(bar) VALUES (0)')
+    except Exception as e:
+        print(e)
+
+    #####
+
     conn.close()

--- a/slonik/__init__.py
+++ b/slonik/__init__.py
@@ -1,3 +1,4 @@
 from .connection import Connection
+from .exceptions import SlonikException
 
-__all__ = ['Connection']
+__all__ = ['Connection', 'SlonikException']

--- a/slonik/connection.py
+++ b/slonik/connection.py
@@ -11,12 +11,6 @@ from slonik._native import ffi
 from slonik._native import lib
 
 
-def buff_to_bytes(buff):
-    if not buff.bytes:
-        return None
-    return bytes(buff.bytes[0:buff.size])
-
-
 def converter(fmt):
     fmt = '>' + fmt
 
@@ -40,8 +34,8 @@ class _Conn(rust.RustObject):
     @classmethod
     def from_dsn(cls, dsn):
         dsn = dsn.encode('utf-8')
-        rv = cls._from_objptr(rust.call(lib.connect, dsn, len(dsn)))
-
+        result = rust.call(lib.connect, dsn, len(dsn))
+        rv = cls._from_objptr(result)
         return rv
 
     def close(self):
@@ -89,11 +83,11 @@ class _Conn(rust.RustObject):
 
         def _get_row_item(row, i):
             item = row._methodcall(lib.row_item, i)
-            typename = buff_to_bytes(item.typename)
+            typename = rust.buff_to_bytes(item.typename)
             if typename is None:
                 return
 
-            value = buff_to_bytes(item.value)
+            value = rust.buff_to_bytes(item.value)
             type_ = self.types.get(typename)
             if type_ is not None:
                 value = type_(value)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,7 @@
 from slonik import Connection
 
 
-def test_from_env(conn):
+def test_from_env():
     conn = Connection.from_env(pguser='this-is', pgpassword='a-test')
     assert conn.dsn.startswith('postgresql://this-is:a-test@')
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,31 @@
+from slonik import Connection
+from slonik import SlonikException
+
+import pytest
+
+
+def test_connection_error():
+    conn = Connection('postgresql://255.255.255.255/db')
+    with pytest.raises(SlonikException) as e:
+        conn._conn
+    assert 'Network is unreachable' in str(e)
+
+
+def test_query_error(conn):
+    with pytest.raises(SlonikException) as e:
+        list(conn.query('SELECT bar FROM foo'))
+    assert 'relation "foo" does not exist' in str(e)
+
+    with pytest.raises(SlonikException) as e:
+        list(conn.query('SELECT bar MORF foo'))
+    assert 'syntax error at or near "foo"' in str(e)
+
+
+def test_execute_error(conn):
+    with pytest.raises(SlonikException) as e:
+        conn.execute('DELETE FROM foo')
+    assert 'relation "foo" does not exist' in str(e)
+
+    with pytest.raises(SlonikException) as e:
+        conn.execute('DELETE MORF foo')
+    assert 'syntax error at or near "MORF"' in str(e)


### PR DESCRIPTION
We now have some error handling instead of panics and/or segmentation faults.
It has to be improved to add different error types.

Next step: split & clean the code.