### PR TITLE
Handle parameters types for queries

### DIFF
--- a/example.py
+++ b/example.py
@@ -39,6 +39,9 @@ if __name__ == '__main__':
     result = conn.get_value('SELECT $1::text', 'abc')
     print(repr(result))
 
+    result = conn.get_value('SELECT $1::float', 42.4)
+    print(repr(result))
+
     #####
 
     conn.execute('BEGIN')

--- a/slonik/query.py
+++ b/slonik/query.py
@@ -36,7 +36,8 @@ class _Query(rust.RustObject):
 class Query:
     serializers = {
         int: get_serializer(b'int4', 'i'),
-        str: lambda s: (b'str', s.encode()),
+        float: get_serializer(b'float8', 'd'),
+        str: lambda s: (b'text', s.encode()),
     }
 
     def __init__(self, _query):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -29,3 +29,10 @@ def test_execute_error(conn):
     with pytest.raises(SlonikException) as e:
         conn.execute('DELETE MORF foo')
     assert 'syntax error at or near "MORF"' in str(e.value)
+
+
+def test_param_type_error(conn):
+    with pytest.raises(SlonikException) as e:
+        conn.get_value('SELECT $1::text', 42)
+    assert str(e.value) == ("type conversion error: cannot convert to or from "
+                            "a Postgres value of type `text`")

--- a/tests/test_parameter_types.py
+++ b/tests/test_parameter_types.py
@@ -1,0 +1,27 @@
+from slonik import SlonikException
+
+import pytest
+
+
+def test_int(conn):
+    assert conn.get_value('SELECT $1::int', 42) == 42
+
+    with pytest.raises(SlonikException) as e:
+        conn.get_value('SELECT $1::int', '42')
+    assert 'type conversion error' in str(e.value)
+
+
+def test_float(conn):
+    assert conn.get_value('SELECT $1::float', 42.4) == 42.4
+
+    with pytest.raises(SlonikException) as e:
+        conn.get_value('SELECT $1::float', '42.4')
+    assert 'type conversion error' in str(e.value)
+
+
+def test_text(conn):
+    assert conn.get_value('SELECT $1::text', 'foo') == 'foo'
+
+    with pytest.raises(SlonikException) as e:
+        conn.get_value('SELECT $1::text', 42)
+    assert 'type conversion error' in str(e.value)


### PR DESCRIPTION
Allow to use different type of parameters.

Parameters are still given as strings, update for an enum/ints will be done later in another pull-request.