### PR TITLE
Fix tests for pytest 5

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,24 +8,24 @@ def test_connection_error():
     conn = Connection('postgresql://255.255.255.255/db')
     with pytest.raises(SlonikException) as e:
         conn._conn
-    assert 'Network is unreachable' in str(e)
+    assert 'Network is unreachable' in str(e.value)
 
 
 def test_query_error(conn):
     with pytest.raises(SlonikException) as e:
         list(conn.query('SELECT bar FROM foo'))
-    assert 'relation "foo" does not exist' in str(e)
+    assert 'relation "foo" does not exist' in str(e.value)
 
     with pytest.raises(SlonikException) as e:
         list(conn.query('SELECT bar MORF foo'))
-    assert 'syntax error at or near "foo"' in str(e)
+    assert 'syntax error at or near "foo"' in str(e.value)
 
 
 def test_execute_error(conn):
     with pytest.raises(SlonikException) as e:
         conn.execute('DELETE FROM foo')
-    assert 'relation "foo" does not exist' in str(e)
+    assert 'relation "foo" does not exist' in str(e.value)
 
     with pytest.raises(SlonikException) as e:
         conn.execute('DELETE MORF foo')
-    assert 'syntax error at or near "MORF"' in str(e)
+    assert 'syntax error at or near "MORF"' in str(e.value)


### PR DESCRIPTION
Use `e.value` to get exception with `pytest.raises` context manager.